### PR TITLE
ignore casing when comparing twitter handles

### DIFF
--- a/bot/common/threads/onboarding.py
+++ b/bot/common/threads/onboarding.py
@@ -290,7 +290,7 @@ def verify_twitter_url(tweet_url, expected_profile):
 
     profile = match.group(1)
 
-    if profile != expected_profile:
+    if profile.lower() != expected_profile.lower():
         errMsg = (
             f"Tweet profile {profile} does not match the supplied"
             f" handle {expected_profile}"


### PR DESCRIPTION
as titled