### PR TITLE
reporting form fix

### DIFF
--- a/bot/common/commands.py
+++ b/bot/common/commands.py
@@ -19,12 +19,11 @@ from bot.common.threads.thread_builder import (
     ThreadKeys,
 )
 from bot.common.threads.onboarding import Onboarding
-from bot.common.threads.report import ReportStep
+from bot.common.threads.report import ReportStep, get_reporting_link
 from bot.common.threads.points import Points
 from bot.common.threads.update import UpdateProfile
 from bot.common.threads.add_dao import AddDao
 from bot.config import (
-    REPORTING_FORM_FMT,
     GUILD_IDS,
     INFO_EMBED_COLOR,
     Redis,
@@ -76,19 +75,19 @@ async def report(ctx):
             ),
         )
 
-    airtableLink = REPORTING_FORM_FMT % ctx.guild.id
+    reporting_form_link = await get_reporting_link(ctx.guild.id)
 
-    if airtableLink:
+    if reporting_form_link:
         _, metadata = await ReportStep(
-            guild_id=ctx.guild.id, cache=Redis, bot=bot, channel=ctx.channel
+            guild_id=ctx.guild.id,
+            cache=Redis,
+            bot=bot,
+            channel=ctx.channel,
+            reporting_link=reporting_form_link,
         ).send(None, ctx.author.id)
         # send message to congrats channel
 
         await ctx.response.send_message(metadata.get("msg"), ephemeral=True)
-    else:
-        await ctx.response.send_message(
-            "No airtable link was provided for this Discord server", ephemeral=True
-        )
 
 
 @bot.slash_command(guild_id=GUILD_IDS, description="Get started with Govrn")
@@ -381,6 +380,10 @@ async def select_guild(ctx, response_embed, error_embed):
 
     await ctx.response.defer()
     guild_metadata = []
+    # TODO: this will set Thread.guild_id to the database id of the guild
+    # there are many places which still use guild_id to represent the discord
+    # id of the guild itself. We should standardize on guild_id vs guild_discord_id
+    # everywhere that's appropriate. Also with user_id vs user_discord_id
     for record_id in airtable_guild_ids:
         g = await get_guild(record_id.get("guild_id"))
         guild_id = g.get("id")

--- a/bot/common/threads/report.py
+++ b/bot/common/threads/report.py
@@ -48,6 +48,8 @@ class ReportStep(BaseStep):
         )
         if message:
             await channel.send(msg)
+
+        # TODO: this will break because of self.guild_id and db changes
         if not await self.cache.get(build_congrats_key(user_id)):
             fields = await get_guild_by_guild_id(self.guild_id)
             congrats_channel_id = fields.get("congrats_channel_id")
@@ -82,6 +84,6 @@ class Report(BaseThread):
 
 
 async def get_reporting_link(guild_discord_id):
-    guild = await get_guild_by_discord_id(guild_discord_id)
+    guild = await get_guild_by_guild_id(guild_discord_id)
     guild_id = guild.get("id")
     return REPORTING_FORM_FMT % guild_id

--- a/bot/common/threads/report.py
+++ b/bot/common/threads/report.py
@@ -23,23 +23,28 @@ class ReportStep(BaseStep):
 
     name = StepKeys.USER_DISPLAY_CONFIRM.value
 
-    def __init__(self, guild_id, cache, bot, channel=None):
+    def __init__(self, guild_id, cache, bot, channel=None, reporting_link=None):
         self.guild_id = guild_id
         self.cache = cache
         self.bot = bot
         self.channel = channel
+        self.reporting_link = reporting_link
 
     async def send(self, message, user_id):
         channel = self.channel
         if message:
             channel = message.channel
 
-        airtableLink = REPORTING_FORM_FMT % self.guild_id
+        link = (
+            REPORTING_FORM_FMT % self.guild_id
+            if self.reporting_link is None
+            else self.reporting_link
+        )
 
         msg = (
             f"Woohoo! Nice job! Community contributions are what keeps"
             " your community thriving 🌞. "
-            f"Report your contributions via the form 👉 {airtableLink}"
+            f"Report your contributions via the form 👉 {link}"
         )
         if message:
             await channel.send(msg)
@@ -74,3 +79,9 @@ class Report(BaseThread):
         return Step(
             current=ReportStep(guild_id=self.guild_id, cache=self.cache, bot=self.bot)
         ).build()
+
+
+async def get_reporting_link(guild_discord_id):
+    guild = await get_guild_by_discord_id(guild_discord_id)
+    guild_id = guild.get("id")
+    return REPORTING_FORM_FMT % guild_id


### PR DESCRIPTION
Changes between moving from airtable to postgres have casued ambiguity in the meaning of "guild_id" causing the reporting form to be returned with the guild's discord id (which breaks) as opposed to the db id. Small fix to unblock this bug. 